### PR TITLE
lava-docs: add "lava run" section

### DIFF
--- a/pages.json
+++ b/pages.json
@@ -5,6 +5,11 @@
     "header": "Run scan"
   },
   {
+    "topic": "run",
+    "file": "build/commands/run.md",
+    "header": "Run single check"
+  },
+  {
     "topic": "init",
     "file": "build/commands/init.md",
     "header": "Init Lava project"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -9,6 +9,7 @@
 # Commands
 
 - [Run scan](commands/scan.md)
+- [Run single check](commands/run.md)
 - [Init Lava project](commands/init.md)
 - [Print Lava version](commands/version.md)
 


### PR DESCRIPTION
This PR adds a new section for the "lava run" command introduced in
Lava v0.6.0.