### PR TITLE
lava-docs: add IaC security to the introduction page

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -12,10 +12,12 @@ In fact, Lava is compatible with the [vulcan-checks][vulcan-checks]
 catalog shipped with Vulcan.
 
 The default Lava configuration covers the following security controls:
-- DAST (Dynamic Application Security Testing)
-- SAST (Static Application Security Testing)
-- SCA (Software Composition Analysis)
-- Secret detection
+- SAST (Static Application Security Testing).
+- SCA (Software Composition Analysis).
+- IaC security (Infrastructure as Code Security).
+- Secret detection.
+- DAST (Dynamic Application Security Testing).
+
 
 For more details, please visit the [Security controls](controls.md)
 section of the documentation.

--- a/src/controls.md
+++ b/src/controls.md
@@ -1,4 +1,4 @@
-# Security Controls
+# Security controls
 
 Behind the scenes Lava uses other security tools and custom security
 checks to perform a security scan. Tools are integrated through what is called


### PR DESCRIPTION
Add IaC security to the list of security controls in the introduction page.